### PR TITLE
ENG-6263: display id token claims as string

### DIFF
--- a/src/components/Authenticated.js
+++ b/src/components/Authenticated.js
@@ -53,12 +53,12 @@ export default function Authenticated(props) {
               alt="Curity HAAPI React Demo"
             />
             <h3>Access Token</h3>
-            <pre className="json-container">{access_token}</pre>
+            <pre id="access-token-container" className="json-container">{access_token}</pre>
             <h3>Scopes</h3>
-            <pre className="json-container">{scope}</pre>
+            <pre id="scopes-container" className="json-container">{scope}</pre>
             <h3>Access token expires in (seconds)</h3>
 
-            <pre className="json-container">{expires_in}</pre>
+            <pre id="token-expire-container" className="json-container">{expires_in}</pre>
 
             <h3>ID Token claims</h3>
             <pre

--- a/src/components/Authenticated.js
+++ b/src/components/Authenticated.js
@@ -61,10 +61,11 @@ export default function Authenticated(props) {
             <pre className="json-container">{expires_in}</pre>
 
             <h3>ID Token claims</h3>
-            <pre
+            <pre 
+              id="tokenClaims"
               className="json-container"
               dangerouslySetInnerHTML={{
-                __html: prettyPrintJson.toHtml(decodeToken(id_token)),
+                __html: JSON.stringify(decodeToken(id_token)),
               }}
             />
           </div>

--- a/src/components/Authenticated.js
+++ b/src/components/Authenticated.js
@@ -61,12 +61,19 @@ export default function Authenticated(props) {
             <pre className="json-container">{expires_in}</pre>
 
             <h3>ID Token claims</h3>
-            <pre 
-              id="tokenClaims"
-              className="json-container"
-              dangerouslySetInnerHTML={{
-                __html: JSON.stringify(decodeToken(id_token)),
+            <pre
+                className="json-container"
+                dangerouslySetInnerHTML={{
+                  __html: prettyPrintJson.toHtml(decodeToken(id_token)),
               }}
+            />
+            <h3>ID Token claims as a string</h3>
+            <pre
+                id="tokenClaims"
+                className="json-container"
+                dangerouslySetInnerHTML={{
+                  __html: JSON.stringify(decodeToken(id_token)),
+                }}
             />
           </div>
         </Well>

--- a/src/components/Authenticated.js
+++ b/src/components/Authenticated.js
@@ -69,6 +69,7 @@ export default function Authenticated(props) {
             />
             <h3>ID Token claims as a string</h3>
             <pre
+                hidden
                 id="tokenClaims"
                 className="json-container"
                 dangerouslySetInnerHTML={{

--- a/src/components/ShowRawResponse.js
+++ b/src/components/ShowRawResponse.js
@@ -46,6 +46,14 @@ export default function ShowRawResponse(props) {
           __html: prettyPrintJson.toHtml(haapiResponse),
         }}
       ></pre>
+      <pre
+        hidden
+        id="response-container"
+        className="json-container"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(haapiResponse),
+        }}
+      ></pre>
     </>
   );
 }


### PR DESCRIPTION
This change is needed to simplify E2E tests' assertions. 

Update: made the additions hidden so nothing changes visually

![image](https://github.com/TransferGo/react-haapi-demo/assets/43465514/a1789351-4cf1-4207-b762-917efe14ad20)
